### PR TITLE
Anpassung an PHP 7.3

### DIFF
--- a/cms/Syntax.php
+++ b/cms/Syntax.php
@@ -747,7 +747,7 @@ class Syntax {
         $tablecontent = "";
         // Tabellenzeilen
 
-        preg_match_all("/(&lt;|&lt;&lt;)(.*)(&gt;|&gt;&gt;)/Umsie", $value, $tablelines);
+        preg_match_all("/(&lt;|&lt;&lt;)(.*)(&gt;|&gt;&gt;)/Umsi", $value, $tablelines);
         foreach ($tablelines[0] as $j => $tablematch) {
             // Kopfzeilen
             if (preg_match("/&lt;&lt;([^&gt;]*)/Umsi", $tablematch)) {


### PR DESCRIPTION
Hallo zusammen,

unter PHP 7.3 wirft cms/Syntax.php mit einer unschönen Warnung um sich. Habe ich behoben, bitte um Merge in den Master.

Beste Grüße
Arvid